### PR TITLE
Radius input for circular leaves

### DIFF
--- a/deadleaves/deadleaves.py
+++ b/deadleaves/deadleaves.py
@@ -1283,7 +1283,7 @@ class LeafTopology:
         leaf_table: pd.DataFrame,
         groupby: str,
         shuffle: bool = True,
-        group_order: str = None,
+        group_order: str | None = None,
         seed: int | None = None,
     ) -> pd.DataFrame:
         """
@@ -1296,8 +1296,9 @@ class LeafTopology:
                 Column containing the groups.
             shuffle (bool):
                 If true shuffle leaf index within group. Defaults to true.
-            group_order (str):
+            group_order (str | None):
                 Order of groups: "ascending", or "descending", or random (None).
+                Defaults to None.
             seed (int | None):
                 Set value for generating a random seed for reproducibility.
                 If None a different random seed will be set at each execution.
@@ -1346,7 +1347,7 @@ class LeafTopology:
             table (pd.DataFrame):
                 Input leaf table.
             seed (int, optional):
-                Random seed for reproducibility.
+                Random seed for reproducibility. Default to None.
 
         Returns:
             pd.DataFrame:

--- a/deadleaves/deadleaves.py
+++ b/deadleaves/deadleaves.py
@@ -100,14 +100,6 @@ class LeafGeometryGenerator:
             self._resolve_position_mask(position_mask)
         self._unpack_parameters()
 
-    leaf_shape_kw: dict[str, list[str]] = {
-        "circular": ["area"],
-        "ellipsoid": ["area", "aspect_ratio", "orientation"],
-        "rectangular": ["area", "aspect_ratio", "orientation"],
-        "polygon": ["area", "n_vertices"],
-    }
-    """Dictionary connecting keys to respective list of shape parameters."""
-
     def _resolve_dependencies(self) -> list[str]:
         """
         Resolve model parameter dependencies.
@@ -146,11 +138,17 @@ class LeafGeometryGenerator:
             ValueError:
                 Provided parameters don't match provided leaf shape.
         """
-        self.params = list(self.shape_param_distributions.keys())
-        if set(self.params) != set(self.leaf_shape_kw[self.leaf_shape]):
+        self.params = set(self.shape_param_distributions.keys()).union(
+            {"x_pos", "y_pos"}
+        )
+        if isinstance(leaf_mask_kw[self.leaf_shape].required, set):
+            required: list[set[str]] = [leaf_mask_kw[self.leaf_shape].required]
+        else:
+            required: list[set[str]] = leaf_mask_kw[self.leaf_shape].required
+        if not any(req <= self.params for req in required):
             raise ValueError(
                 f"Model with {self.leaf_shape} shapes expects parameters: "
-                f"{self.leaf_shape_kw[self.leaf_shape]} but received {self.params}"
+                f"{leaf_mask_kw[self.leaf_shape].required} but received {self.params}"
             )
         sampling_box = bounding_box(self.position_mask, 1)
         if sampling_box is None:
@@ -1134,38 +1132,76 @@ class LeafTopology:
                 If required columns are missing, unknown shapes are present,
                 or required parameters contain NaNs.
         """
+        errors = []
         cols = set(leaf_table.columns)
 
         # --- base columns ---
         base_required = {"leaf_shape", "leaf_idx"}
         missing = base_required - cols
         if missing:
-            raise ValueError(f"Missing base columns: {missing}")
+            errors.append(f"Missing base columns: {missing}")
+
+        if "leaf_shape" not in cols:
+            raise ValueError("\n".join(errors))
 
         # --- unknown shapes ---
         unknown = set(leaf_table["leaf_shape"]) - set(leaf_mask_kw)
         if unknown:
-            raise ValueError(f"Unknown shapes: {unknown}")
+            errors.append(f"Unknown shapes: {unknown}")
 
         # --- per-shape validation ---
         for shape, group in leaf_table.groupby("leaf_shape"):
+            if shape not in leaf_mask_kw:
+                continue
             spec = leaf_mask_kw[shape]
+            required = spec.required
 
-            # missing required columns
-            missing_cols = spec.required - cols
-            if missing_cols:
-                raise ValueError(
-                    f"Shape '{shape}' missing required columns: {missing_cols}"
-                )
+            # Case 1: Single set of required parameters
+            if isinstance(required, set):
+                # missing required columns
+                missing_cols = required - cols
+                if missing_cols:
+                    errors.append(
+                        f"Shape '{shape}' missing required columns: {missing_cols}"
+                    )
+                    continue
 
-            # NaN check in required columns for rows of this shape
-            nan_mask = group[list(spec.required)].isna().any(axis=1)
-            if nan_mask.any():
-                bad_rows = group.index[nan_mask].tolist()
-                raise ValueError(
-                    f"Shape '{shape}' has NaNs in required columns "
-                    f"for rows: {bad_rows}"
-                )
+                # NaN check in required columns for rows of this shape
+                nan_mask = group[list(required)].isna().any(axis=1)
+                if nan_mask.any():
+                    bad_rows = group.index[nan_mask].tolist()
+                    errors.append(
+                        f"Shape '{shape}' has NaNs in required columns "
+                        f"for rows: {bad_rows}"
+                    )
+
+            # Case 2: Multiple options for required parameters
+            elif isinstance(required, list):
+                # missing required columns
+                required_sets = [rset for rset in required if rset <= cols]
+
+                if not required_sets:
+                    errors.append(
+                        f"Shape '{shape}' missing required columns. "
+                        f"Needs on of: {required}"
+                    )
+                    continue
+
+                # NaN check in required columns for rows of this shape
+                bad_rows = []
+                for idx, row in group.iterrows():
+                    if not any(
+                        not row[list(rset)].isna().any() for rset in required_sets
+                    ):
+                        bad_rows.append(idx)
+                if bad_rows:
+                    errors.append(
+                        f"Shape '{shape}' has NaNs in required columns "
+                        f"for rows: {bad_rows}"
+                    )
+
+            if errors:
+                raise ValueError("Geometry validation failed:\n" + "\n".join(errors))
 
     def _cull_outside_canvas(
         self,

--- a/deadleaves/leaf_masks.py
+++ b/deadleaves/leaf_masks.py
@@ -31,7 +31,10 @@ class LeafMaskSpec:
 
 
 def get_leaf_mask_kw() -> dict[str, LeafMaskSpec]:
-    """Return dictionary mapping leaf shapes to their mask functions and required parameters."""
+    """
+    Return dictionary mapping leaf shapes to their mask functions
+    and required parameters.
+    """
     return {
         "circular": LeafMaskSpec(
             fn=circular,

--- a/deadleaves/leaf_masks.py
+++ b/deadleaves/leaf_masks.py
@@ -74,12 +74,19 @@ def circular(
             Leaf mask.
     """
     X, Y = index_grid
-    if params["area"] < 0:
-        raise ValueError("Provided area must be non-negative.")
+    keys = params.keys() if isinstance(params, dict) else params.index
+    if not (("area" in keys) ^ ("radius" in keys)):
+        raise ValueError("Either radius or area must be provided.")
+    for key in ("area", "radius"):
+        if key in keys and params[key] < 0:
+            raise ValueError(f"Provided {key} must be non-negative.")
     dist_from_center = torch.sqrt(
         (X - params["x_pos"]) ** 2 + (Y - params["y_pos"]) ** 2
     )
-    mask = dist_from_center <= torch.sqrt(params["area"] / torch.pi)
+    if "area" in keys:
+        mask = dist_from_center <= torch.sqrt(params["area"] / torch.pi)
+    else:
+        mask = dist_from_center <= params["radius"]
     return mask
 
 

--- a/deadleaves/leaf_masks.py
+++ b/deadleaves/leaf_masks.py
@@ -21,7 +21,7 @@ class LeafMaskSpec:
 
     fn: MaskFn
     """Leaf mask function, mapping shape parameters to a leaf mask."""
-    required: set[str]
+    required: set[str] | list[set[str]]
     """Parameters of the leaf shape."""
 
 
@@ -35,7 +35,7 @@ def get_leaf_mask_kw() -> dict[str, LeafMaskSpec]:
     return {
         "circular": LeafMaskSpec(
             fn=circular,
-            required={"x_pos", "y_pos", "area"},
+            required=[{"x_pos", "y_pos", "area"}, {"x_pos", "y_pos", "radius"}],
         ),
         "ellipsoid": LeafMaskSpec(
             fn=ellipsoid,

--- a/docs/user_guides/distributions.md
+++ b/docs/user_guides/distributions.md
@@ -303,9 +303,11 @@ f(x) = \begin{cases} \frac{k-1}{x_{\min}^{1-k}-x_{\max}^{1-k}}\cdot x^{-k}, & \t
 $$
 
 For continuity with respect to $k$ the distribution for $k=1$ is given by
+
 $$
 f(x) = \begin{cases} \frac{1}{\ln(x_{\max})-\ln(x_{\min})}\cdot x^{-1}, & \text{for } x\in[x_{\min}, x_{\max}] \\ 0, & \text{else.}  \end{cases}
 $$
+
 For $k=0$ the distribution equals a uniform distribution between the lower and the upper bound.
 
 ```{code-cell}

--- a/docs/user_guides/shapes.md
+++ b/docs/user_guides/shapes.md
@@ -28,7 +28,7 @@ For comparability all shape sizes are parameterized via an `area` parameter, whi
 
 ## Circles
 
-Circular leaves (`leaf_shape = "circular"`) are the simplest, requiring only the `area` distribution:
+Circular leaves (`leaf_shape = "circular"`) are the simplest, requiring only the `area` <u>or</u> `radius` distribution:
 
 ```python
 {
@@ -36,17 +36,26 @@ Circular leaves (`leaf_shape = "circular"`) are the simplest, requiring only the
 }
 ```
 
-The leaf mask for a circular leaf with position $(\bar{x},\bar{y})$ and area $A$ is then generated via
+or
+
+```python
+{
+    "radius": <distribution>
+}
+```
+
+The leaf mask for a circular leaf with position $(\bar{x},\bar{y})$ and area $A$ or radius $r$ is then generated via
 
 $$
     L(x,y) = \begin{cases} 
-    1, & \text{if } \sqrt{(x-\bar{x})^2 + (y-\bar{y})^2} \leq \sqrt{\frac{A}{\pi}} \\
+    1, & \text{if } \sqrt{(x-\bar{x})^2 + (y-\bar{y})^2} \leq \sqrt{\frac{A}{\pi}} = r \\
     0, & \text{else.}
     \end{cases}
 $$
 
 ```{tip}
-To generate images with powerlaw distributed leaf radius (for a $1/f$ power spectrum) simply use a powerlaw distributed area with exponent `k` half of the value you would use for the radius.
+To generate images with powerlaw distributed leaf radius (for a $1/f$ power spectrum) simply use a powerlaw distributed area with exponent `k`.
+For parameterization via the area the value of `k` should be half of what you would use for the radius to achieve the same distribution.
 ```
 
 **Example**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deadleaves"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     { name = "Lynn Schmittwilken", email = "lynn.schmittwilken@tu-darmstadt.de" },
     { name = "Swantje Mahncke", email = "swantje.mahncke@tu-darmstadt.de" },

--- a/tests/test_leaf_masks.py
+++ b/tests/test_leaf_masks.py
@@ -7,12 +7,15 @@ X, Y = torch.meshgrid(torch.arange(10), torch.arange(10), indexing="ij")
 
 # --- Test: Circular leaf mask --------------------------------------------------------
 
+test_circle_params = [("area", torch.pi * 4), ("radius", 2)]
 
-def test_circles():
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles(key, value):
     params = {
         "x_pos": torch.tensor(5.0),
         "y_pos": torch.tensor(5.0),
-        "area": torch.tensor(torch.pi * 4),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
 
@@ -32,22 +35,30 @@ def test_circles():
     assert mask[5, 5 - 2] == mask[5, 5 + 2]
 
 
-def test_circles_zero_area():
+test_circle_params = [("area", 0.0), ("radius", 0.0)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_zero_area(key, value):
     params = {
         "x_pos": torch.tensor(4.0),
         "y_pos": torch.tensor(6.0),
-        "area": torch.tensor(0.0),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
     assert mask.sum() == 1
     assert mask[4, 6]
 
 
-def test_circles_small_area():
+test_circle_params = [("area", 1e-6), ("radius", 1e-6)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_small_area(key, value):
     params = {
         "x_pos": torch.tensor(4.0),
         "y_pos": torch.tensor(4.0),
-        "area": torch.tensor(1e-6),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
 
@@ -55,21 +66,29 @@ def test_circles_small_area():
     assert mask[4, 4]
 
 
-def test_circles_large_area():
+test_circle_params = [("area", torch.pi * 100), ("radius", 10)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_large_area(key, value):
     params = {
         "x_pos": torch.tensor(5.0),
         "y_pos": torch.tensor(5.0),
-        "area": torch.tensor(torch.pi * 100),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
     assert mask.all()
 
 
-def test_circles_non_integer_center():
+test_circle_params = [("area", torch.pi * 4), ("radius", 2)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_non_integer_center(key, value):
     params = {
         "x_pos": torch.tensor(4.5),
         "y_pos": torch.tensor(4.5),
-        "area": torch.tensor(torch.pi * 4),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
     assert mask[4, 4]
@@ -77,22 +96,30 @@ def test_circles_non_integer_center():
     assert not mask[7, 7]
 
 
-def test_circles_empty():
+test_circle_params = [("area", 0.0), ("radius", 0.0)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_empty(key, value):
     params = {
         "x_pos": torch.tensor(4.5),
         "y_pos": torch.tensor(4.5),
-        "area": torch.tensor(0.0),
+        key: torch.tensor(value),
     }
     mask = circular((X, Y), params)
     assert not mask.any()
 
 
-def test_circles_pandas():
+test_circle_params = [("area", torch.pi * 4), ("radius", 2)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_pandas(key, value):
     params = pd.Series(
         {
             "x_pos": torch.tensor(5.0),
             "y_pos": torch.tensor(5.0),
-            "area": torch.tensor(torch.pi * 4),
+            key: torch.tensor(value),
         }
     )
     mask = circular((X, Y), params)
@@ -101,11 +128,15 @@ def test_circles_pandas():
     assert mask[5, 5]
 
 
-def test_circles_invalid_args():
+test_circle_params = [("area", -1), ("radius", -1)]
+
+
+@pytest.mark.parametrize("key, value", test_circle_params)
+def test_circles_invalid_args(key, value):
     params = {
         "x_pos": torch.tensor(5.0),
         "y_pos": torch.tensor(5.0),
-        "area": torch.tensor(-1.0),
+        key: torch.tensor(value),
     }
     with pytest.raises(ValueError):
         circular((X, Y), params)


### PR DESCRIPTION
- Allow leaf parametrization for circular leaves via radius or area
- Adjust all parameter validations to run on LeafMaskSpec.required (i.e. remove redundant leaf_shape_kw dictionary)
- Adjust required shape parameters to allow a single set of required parameters or a list of multiple possible parameter sets
- Add leaf mask tests for parametrization via radius

Closes #8 