### PR TITLE
Mondrians

### DIFF
--- a/examples/gallery/plot_ex15.py
+++ b/examples/gallery/plot_ex15.py
@@ -1,0 +1,27 @@
+"""
+Gray Mondrian
+===========================
+
+Inspired by MaxEvoy and Paradiso (2001)
+"""
+
+from deadleaves import LeafGeometryGenerator, LeafAppearanceSampler, ImageRenderer
+
+model = LeafGeometryGenerator(
+    leaf_shape="rectangular",
+    shape_param_distributions={
+        "area": {"uniform": {"low": 10000.0, "high": 50000.0}},
+        "aspect_ratio": {"constant": {"value": 1}},
+        "orientation": {"constant": {"value": 0}},
+    },
+    image_shape=(512, 731),
+)
+leaf_table, segmentation_map = model.generate_segmentation()
+colormodel = LeafAppearanceSampler(leaf_table=leaf_table)
+colormodel.sample_color(
+    color_param_distributions={"gray": {"uniform": {"low": 0.1, "high": 0.9}}}
+)
+
+renderer = ImageRenderer(colormodel.leaf_table, segmentation_map)
+renderer.render_image()
+renderer.show()

--- a/examples/gallery/plot_ex16.py
+++ b/examples/gallery/plot_ex16.py
@@ -1,0 +1,31 @@
+"""
+Color Mondrian
+===========================
+
+Inspired by Land (1985) and Barbur et al. (2004)
+"""
+
+from deadleaves import LeafGeometryGenerator, LeafAppearanceSampler, ImageRenderer
+
+model = LeafGeometryGenerator(
+    leaf_shape="rectangular",
+    shape_param_distributions={
+        "area": {"uniform": {"low": 50000.0, "high": 100000.0}},
+        "aspect_ratio": {"uniform": {"low": 0.1, "high": 2}},
+        "orientation": {"constant": {"value": 0}},
+    },
+    image_shape=(512, 731),
+)
+leaf_table, segmentation_map = model.generate_segmentation()
+colormodel = LeafAppearanceSampler(leaf_table=leaf_table)
+colormodel.sample_color(
+    color_param_distributions={
+        "H": {"uniform": {"low": 0.0, "high": 1.0}},
+        "S": {"constant": {"value": 0.6}},
+        "V": {"constant": {"value": 0.8}},
+    }
+)
+
+renderer = ImageRenderer(colormodel.leaf_table, segmentation_map)
+renderer.render_image()
+renderer.show()


### PR DESCRIPTION
This PR adds examples for gray and colored mondrian style stimuli generated with the deadleaves package to the gallery of the docs.

<img width="769" height="490" alt="grafik" src="https://github.com/user-attachments/assets/7a436bc9-9fd7-4b4b-ae63-8ae18df7c912" />

<img width="764" height="769" alt="grafik" src="https://github.com/user-attachments/assets/ad1efa90-cd50-4e38-9152-758ffad27e76" />

<img width="767" height="749" alt="grafik" src="https://github.com/user-attachments/assets/67f93015-b624-4908-897b-ca6304eb8f02" />

based on review: openjournals/joss-reviews#10531